### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -24,7 +24,7 @@ jobs:
         echo "::set-output name=tag::$(git rev-parse --short HEAD)"
     - name: build and push docker image
       id: docker
-      uses: elgohr/Publish-Docker-Github-Action@master      
+      uses: elgohr/Publish-Docker-Github-Action@v5      
       with:
         name: onboard.azurecr.io/gitopsnjs
         registry: onboard.azurecr.io

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -24,7 +24,7 @@ jobs:
 
     - name: build and push docker image
       id: docker
-      uses: elgohr/Publish-Docker-Github-Action@master      
+      uses: elgohr/Publish-Docker-Github-Action@v5      
       with:
         name: onboard.azurecr.io/gitopsnjs
         registry: onboard.azurecr.io

--- a/.github/workflows/stage.yaml
+++ b/.github/workflows/stage.yaml
@@ -25,7 +25,7 @@ jobs:
         echo "::set-output name=tag::$(git rev-parse --short HEAD)"
     - name: build and push docker image
       id: docker
-      uses: elgohr/Publish-Docker-Github-Action@master      
+      uses: elgohr/Publish-Docker-Github-Action@v5      
       with:
         name: onboard.azurecr.io/gitopsnjs
         registry: onboard.azurecr.io


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore